### PR TITLE
Update widget test for initial screen

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leitor_palavras/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Initial screen shows selection prompt',
+      (WidgetTester tester) async {
+    // Build the app and trigger a frame.
+    await tester.pumpWidget(LeitorApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the default message is displayed when no file is loaded.
+    expect(find.text('Selecione ou carregue um arquivo'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace `MyApp` references with `LeitorApp`
- verify that the initial screen shows the message "Selecione ou carregue um arquivo"

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68482a3c7a2c832ab56333576e9872c1